### PR TITLE
Carousel: Replace anchor tags by Link components to prevent page reload

### DIFF
--- a/src/component/header_carrousel.js
+++ b/src/component/header_carrousel.js
@@ -1,6 +1,7 @@
 //=============================== Header ==========================
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Carousel } from 'react-carousel3';
 
 
@@ -11,26 +12,26 @@ const HeaderCarrousel = () => {
         <div className="mt-[-170px] mb-12">
             <Carousel height={400} width={'100%'} yOrigin={32} yRadius={32}>
 
-                <a href='#competences'>
+                <Link to='#competences'>
                     <div key={1} className="w-44 h-44 p-2 hover:scale-110">
                         <img alt="" src="images/competences.png" className=''/>
                         <h3 className='text-center text-xl uppercase'>Competences</h3>
                     </div>
-                </a>
+                </Link>
 
-                <a href='#portfolio'>
+                <Link to='#portfolio'>
                     <div key={1} className="w-44 h-44 p-2 hover:scale-110">
                         <img alt="" src="images/portfolio.png" />
                         <h3 className='text-center text-xl uppercase'>Portfolio</h3>
                     </div>
-                </a>
+                </Link>
 
-                <a href='#contact'>
+                <Link to='#contact'>
                     <div key={1} className="w-44 h-44 p-2 hover:scale-110">
                         <img alt="" src="images/contact.png" />
                         <h3 className='text-center text-xl uppercase'>Contact</h3>
                     </div>
-                </a>
+                </Link>
 
             </Carousel>
 


### PR DESCRIPTION
This should fix the 404 error problem when you click on a carousel link. Let me know how it goes 😉